### PR TITLE
Add missing site.baseurl value.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: i am trask
 subtitle: interesting
 email: liamtrask@gmail.com
 description: "Write your site description here. It will be used as your sites meta description as well!"
-baseurl: ""
+baseurl: "http://iamtrask.github.io"
 url: "http://iamtrask.github.io"
 twitter_username: iamtrask
 github_username:  iamtrask


### PR DESCRIPTION
The prev/next buttons on the bottom of posts were using localhost rather than the url. I could have changed the template to use site.url instead of site.baseurl, but this seemed like an easier fix.
