### PR TITLE
Fixing previous and next links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -42,12 +42,12 @@ layout: default
                 <ul class="pager">
                     {% if page.previous.url %}
                     <li class="previous">
-                        <a href="{{ site.baseurl }}/{{page.previous.url}}" data-toggle="tooltip" data-placement="top" title="{{page.previous.title}}">&larr; Previous Post</a> 
+                        <a href="{{ site.url }}/{{page.previous.url}}" data-toggle="tooltip" data-placement="top" title="{{page.previous.title}}">&larr; Previous Post</a> 
                     </li>
                     {% endif %} 
                     {% if page.next.url %}
                     <li class="next">
-                        <a href="{{ site.baseurl }}/{{page.next.url}}" data-toggle="tooltip" data-placement="top" title="{{page.next.title}}">Next Post &rarr;</a>
+                        <a href="{{ site.url }}/{{page.next.url}}" data-toggle="tooltip" data-placement="top" title="{{page.next.title}}">Next Post &rarr;</a>
                     </li>
                     {% endif %} 
                 </ul>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -42,12 +42,12 @@ layout: default
                 <ul class="pager">
                     {% if page.previous.url %}
                     <li class="previous">
-                        <a href="{{ site.url }}/{{page.previous.url}}" data-toggle="tooltip" data-placement="top" title="{{page.previous.title}}">&larr; Previous Post</a> 
+                        <a href="{{ page.previous.url | prepend: site.baseurl | replace: '//', '/' }}" data-toggle="tooltip" data-placement="top" title="{{page.previous.title}}">&larr; Previous Post</a> 
                     </li>
                     {% endif %} 
                     {% if page.next.url %}
                     <li class="next">
-                        <a href="{{ site.url }}/{{page.next.url}}" data-toggle="tooltip" data-placement="top" title="{{page.next.title}}">Next Post &rarr;</a>
+                        <a href="{{ page.next.url | prepend: site.baseurl | replace: '//', '/' }}" data-toggle="tooltip" data-placement="top" title="{{page.next.title}}">Next Post &rarr;</a>
                     </li>
                     {% endif %} 
                 </ul>


### PR DESCRIPTION
Since this project is based in the root folder. site.url makes more sense.

Also, the previous implementation is broken. you can check it by going to a post page and clicking previous/next