### PR TITLE
Add Plausible analytics

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -30,4 +30,11 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
+    <!-- Privacy-friendly analytics by Plausible -->
+    <script async src="https://plausible.io/js/pa-ep2CLOwIll8ycdBDUXNKX.js"></script>
+    <script>
+      window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+      plausible.init()
+    </script>
+
 </head>


### PR DESCRIPTION
## Summary
- Adds Plausible analytics snippet to `_includes/head.html` (loads on all pages)
- Privacy-friendly, cookie-free alternative to Google Analytics

## Test plan
- [ ] Verify the Plausible script loads on any page (check Network tab in dev tools)
- [ ] Confirm no impact on page load performance (script is `async`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)